### PR TITLE
Refactor backend API

### DIFF
--- a/client.http
+++ b/client.http
@@ -65,6 +65,34 @@ Content-Type: application/json
 {
   "cocktails": [
     { "name": "アイリッシュコーヒー" },
+    { "name": "アイ・オープナー" },
+    { "name": "アクダクト" },
+    { "name": "アドニス" },
+    { "name": "アフィニティ" }
+  ]
+}
+
+###
+
+POST http://localhost:8000/api/message
+Content-Type: application/json
+
+{
+  "cocktails": [
+    { "name": "アイリッシュコーヒー" },
+    { "name": "アイリッシュコーヒー" },
+    { "name": "アイ・オープナー" }
+  ]
+}
+
+###
+
+POST http://localhost:8000/api/message
+Content-Type: application/json
+
+{
+  "cocktails": [
+    { "name": "アイリッシュコーヒー" },
     { "name": "アイ・オープナー" }
   ]
 }

--- a/private/cocktails.jsonc
+++ b/private/cocktails.jsonc
@@ -11,5 +11,20 @@
     "name": "アイ・オープナー",
     "word": "運命の出会い",
     "color": "#4a1b11"
+  },
+  {
+    "name": "アクダクト",
+    "word": "時の流れに身を任せて",
+    "color": "#ffffff"
+  },
+  {
+    "name": "アドニス",
+    "word": "謙虚",
+    "color": "#ffffff"
+  },
+  {
+    "name": "アフィニティ",
+    "word": "触れ合いたい",
+    "color": "#ffffff"
   }
 ]

--- a/src/api/router/cocktail.test.ts
+++ b/src/api/router/cocktail.test.ts
@@ -7,27 +7,21 @@ Deno.test("Cocktail API", async (t: Deno.TestContext) => {
   await t.step("GET /", async () => {
     const res: Response = await app.request("/");
 
-    assertEquals(await res.json(), {
-      success: false,
-      message: 'The "name" query is required',
-    });
+    assertEquals(await res.text(), 'The "name" query is required');
     assertEquals(res.status, STATUS_CODE.BadRequest);
   });
 
   await t.step("GET /?name=none", async () => {
     const res: Response = await app.request("/?name=none");
 
-    assertEquals(await res.json(), {
-      success: false,
-      message: 'The cocktail, "none" not found',
-    });
+    assertEquals(await res.text(), 'The cocktail, "none" not found');
     assertEquals(res.status, STATUS_CODE.NotFound);
   });
 
   await t.step("GET /?name=アイリッシュコーヒー", async () => {
     const res: Response = await app.request("/?name=アイリッシュコーヒー");
 
-    assertEquals((await res.json()).success, true);
+    assertExists(await res.json());
     assertEquals(res.status, STATUS_CODE.OK);
   });
 

--- a/src/api/router/cocktail.ts
+++ b/src/api/router/cocktail.ts
@@ -23,18 +23,14 @@ export const app = new Hono()
   .get("/", (ctx: Context) => {
     const name: string | undefined = ctx.req.query("name");
     if (!name) {
-      return ctx.json(
-        { success: false, message: 'The "name" query is required' },
-        STATUS_CODE.BadRequest,
-      );
+      return ctx.text('The "name" query is required', STATUS_CODE.BadRequest);
     }
 
     const cocktail: Cocktail | undefined = cocktails.find((c: Cocktail) =>
       c.name === name
     );
-    return cocktail ? ctx.json({ success: true, data: cocktail }) : ctx.json(
-      { success: false, message: `The cocktail, "${name}" not found` },
-      STATUS_CODE.NotFound,
-    );
+    return cocktail
+      ? ctx.json(cocktail)
+      : ctx.text(`The cocktail, "${name}" not found`, STATUS_CODE.NotFound);
   })
   .get("/all", (ctx: Context) => ctx.json(cocktails));

--- a/src/api/router/message.test.ts
+++ b/src/api/router/message.test.ts
@@ -47,13 +47,49 @@ Deno.test("Message API", async (t: Deno.TestContext) => {
     assertEquals(res.status, STATUS_CODE.BadRequest);
   });
 
-  await t.step("POST /", async () => {
+  await t.step("POST / (not found)", async () => {
     const res: Response = await app.request("/", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
         cocktails: [
           { name: "not-found" },
+        ],
+      }),
+    });
+
+    assertExists(await res.text());
+    assertEquals(res.status, STATUS_CODE.BadRequest);
+  });
+
+  await t.step("POST / (too many items)", async () => {
+    const res: Response = await app.request("/", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        cocktails: [
+          { "name": "アイリッシュコーヒー" },
+          { "name": "アイ・オープナー" },
+          { "name": "アクダクト" },
+          { "name": "アドニス" },
+          { "name": "アフィニティ" },
+        ],
+      }),
+    });
+
+    assertExists(await res.text());
+    assertEquals(res.status, STATUS_CODE.BadRequest);
+  });
+
+  await t.step("POST / (duplicate items)", async () => {
+    const res: Response = await app.request("/", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        cocktails: [
+          { name: "アイリッシュコーヒー" },
+          { name: "アイリッシュコーヒー" },
+          { name: "アイ・オープナー" },
         ],
       }),
     });

--- a/src/api/router/message.test.ts
+++ b/src/api/router/message.test.ts
@@ -7,20 +7,14 @@ Deno.test("Message API", async (t: Deno.TestContext) => {
   await t.step("GET /", async () => {
     const res: Response = await app.request("/");
 
-    assertEquals(await res.json(), {
-      success: false,
-      message: 'The "id" query is required',
-    });
+    assertEquals(await res.text(), 'The "id" query is required');
     assertEquals(res.status, STATUS_CODE.BadRequest);
   });
 
   await t.step("GET /?id=none", async () => {
     const res: Response = await app.request("/?id=none");
 
-    assertEquals(await res.json(), {
-      success: false,
-      message: 'The message, "none" not found',
-    });
+    assertEquals(await res.text(), 'The message, "none" not found');
     assertEquals(res.status, STATUS_CODE.NotFound);
   });
 
@@ -30,15 +24,12 @@ Deno.test("Message API", async (t: Deno.TestContext) => {
     );
 
     assertEquals(await res.json(), {
-      "success": true,
-      "data": {
-        "id": "62095b31-b643-4566-9e69-7edc9c901fea",
-        "date": "2020-01-01T00:00:00.000Z",
-        "cocktails": [
-          { "name": "アイリッシュコーヒー" },
-          { "name": "アイ・オープナー" },
-        ],
-      },
+      "id": "62095b31-b643-4566-9e69-7edc9c901fea",
+      "date": "2020-01-01T00:00:00.000Z",
+      "cocktails": [
+        { "name": "アイリッシュコーヒー" },
+        { "name": "アイ・オープナー" },
+      ],
     });
     assertEquals(res.status, STATUS_CODE.OK);
   });
@@ -52,7 +43,7 @@ Deno.test("Message API", async (t: Deno.TestContext) => {
       }),
     });
 
-    assertEquals((await res.json()).success, false);
+    assertExists(await res.text());
     assertEquals(res.status, STATUS_CODE.BadRequest);
   });
 
@@ -67,9 +58,10 @@ Deno.test("Message API", async (t: Deno.TestContext) => {
       }),
     });
 
-    assertEquals((await res.json()).success, false);
+    assertExists(await res.text());
     assertEquals(res.status, STATUS_CODE.BadRequest);
   });
+
   await t.step("POST /", async () => {
     const res: Response = await app.request("/", {
       method: "POST",
@@ -82,7 +74,7 @@ Deno.test("Message API", async (t: Deno.TestContext) => {
       }),
     });
 
-    assertEquals((await res.json()).success, true);
+    assertExists(await res.text());
     assertEquals(res.status, STATUS_CODE.OK);
   });
 

--- a/src/api/router/message.ts
+++ b/src/api/router/message.ts
@@ -40,19 +40,15 @@ export const app = new Hono()
   .get("/", (ctx: Context) => {
     const id: string | undefined = ctx.req.query("id");
     if (!id) {
-      return ctx.json(
-        { success: false, message: 'The "id" query is required' },
-        STATUS_CODE.BadRequest,
-      );
+      return ctx.text('The "id" query is required', STATUS_CODE.BadRequest);
     }
 
     const message: Message | undefined = messages.find((m: Message) =>
       m.id === id
     );
-    return message ? ctx.json({ success: true, data: message }) : ctx.json(
-      { success: false, message: `The message, "${id}" not found` },
-      STATUS_CODE.NotFound,
-    );
+    return message
+      ? ctx.json(message)
+      : ctx.text(`The message, "${id}" not found`, STATUS_CODE.NotFound);
   })
   .post(
     "/",
@@ -63,23 +59,18 @@ export const app = new Hono()
           const res: Response = await cocktailApi.request(
             `/?name=${cocktail.name}`,
           );
-          const result: { success: boolean; message: string } = await res
-            .json();
-          if (!result.success) throw new Error(result.message);
+          if (!res.ok) throw new Error(await res.json());
         }
         return data;
       } catch (error) {
-        return ctx.json(
-          { success: false, message: error.message },
-          STATUS_CODE.BadRequest,
-        );
+        return ctx.text(error.message, STATUS_CODE.BadRequest);
       }
     }),
     async (ctx: Context) => {
       const data: Message = await ctx.req.json();
       const id: string = crypto.randomUUID();
       messages.push({ ...data, id, date: new Date() });
-      return ctx.json({ success: true, data: id });
+      return ctx.text(id);
     },
   )
   .get("/all", (ctx: Context) => ctx.json(messages));

--- a/src/api/utils/types.ts
+++ b/src/api/utils/types.ts
@@ -1,8 +1,10 @@
 import {
   array,
+  checkItems,
   date,
   hexColor,
   InferOutput,
+  maxLength,
   nonEmpty,
   optional,
   pick,
@@ -30,13 +32,33 @@ export const Cocktail = strictObject({
 export type Cocktail = InferOutput<typeof Cocktail>;
 
 /**
+ * Cocktail name API validation
+ * @internal
+ */
+export const CocktailName = pick(Cocktail, ["name"]);
+
+/**
+ * Cocktail name type
+ */
+export type CocktailName = InferOutput<typeof CocktailName>;
+
+/**
  * Message API validation
  * @internal
  */
 export const Message = strictObject({
   id: optional(pipe(string(), uuid(), trim(), nonEmpty())),
   date: optional(date()),
-  cocktails: pipe(array(pick(Cocktail, ["name"])), nonEmpty()),
+  cocktails: pipe(
+    array(CocktailName),
+    nonEmpty(),
+    maxLength(4),
+    checkItems(
+      (item: CocktailName, index: number, array: CocktailName[]) =>
+        array.map((c: CocktailName) => c.name).indexOf(item.name) === index,
+      "Invalid items: No duplicate names allowed",
+    ),
+  ),
 });
 
 /**


### PR DESCRIPTION
- It doesn't return the `success` field to use `Response.status`
- Validate too many or duplicated items